### PR TITLE
Refactor initialize_engine and update test_bert

### DIFF
--- a/patrickstar/core/client.py
+++ b/patrickstar/core/client.py
@@ -38,7 +38,6 @@ class PatrickStarClient(object):
     def __init__(self,
                  rank: int,
                  default_chunk_size: int,
-                 warmup=True,
                  is_fp16=False):
         """
         管理一个Process的Param, AccGrad, OS数据。
@@ -63,7 +62,7 @@ class PatrickStarClient(object):
         self.default_chunk_size = default_chunk_size
         self._time_profile = True
 
-        # 通过运行一次迭代来动态进行chunk schduling
+        # 通过运行一次迭代来动态进行chunk scheduling
         self._is_fp16 = is_fp16
 
         self._chunk_id = -1


### PR DESCRIPTION
This PR refactored the `intiailize_engine` function. Currently, it looks like:

```python
def initialize_engine(model_func, client, config=None)
```

where `model_func` is a callable that can create a `nn.Module` with `model_func()`, `client` is a predefined `PatrickStarClient` and `config` is the configuration for anything else.

For now, `config` only contains hyperparameters of adam. And its format is aligned to [deepspeed config json](https://www.deepspeed.ai/docs/config-json/#optimizer-parameters).

Internally, we moved the `PatrickStarManager` and `Init` context manager into `initialize_engine` so that there is less for users to worry about.