### PR TITLE
Early return on hook registration and only print fp16 param access info

### DIFF
--- a/patrickstar/core/chunk_list.py
+++ b/patrickstar/core/chunk_list.py
@@ -285,7 +285,7 @@ class ChunkList(object):
                 f"Call last_chunk_id on an empty {chunk_type} chunk list")
         return self.chunk_type_to_id_list_map[chunk_type][-1]
 
-    def generate_chunk(self) -> (int, Chunk):
+    def generate_chunk(self):
         for chunk_id, chunk in self.chunk_id_to_chunk_dict_map.items():
             yield chunk_id, chunk
 
@@ -372,3 +372,13 @@ class ChunkList(object):
                 f'** {chunk_id}, {chunk.get_device()}, {chunk.get_chunk_space()}, '
                 f'{chunk.data_type}, {chunk.get_device()}, {chunk.get_status()}'
             )
+
+    def display_access_info(self):
+        if get_rank() == 0:
+            logger.info('----------- SHOW ACCESS INFO -----------')
+            for chunk_id in self.chunk_type_to_id_list_map[ChunkListType.PARAM_FP16]:
+                chunk = self.chunk_id_to_chunk_dict_map[chunk_id]
+                logger.debug(
+                    f'\t {chunk_id} cpu_access_moments {chunk.cpu_access_moments}')
+                logger.debug(
+                    f'\t {chunk_id} gpu_access_moments {chunk.gpu_access_moments}')

--- a/patrickstar/core/hook.py
+++ b/patrickstar/core/hook.py
@@ -222,6 +222,12 @@ def _register_hooks_recursively(module, client, name=""):
         logger.debug(f"{child.__class__.__name__}")
         _register_hooks_recursively(child, client, name + child_name)
 
+    # Early return on modules with no parameters or buffers that
+    # are not in their children.
+    if (len(list(module.named_parameters(recurse=False))) == 0 and
+        len(list(module.named_buffers(recurse=False))) == 0):
+        return
+
     # 如下两个hook和backward的hook是否重复
     def _pre_forward_module_hook(module, *args):
         pre_sub_module_forward_function(module, client, name)

--- a/patrickstar/ops/fp16_cpu_adam.py
+++ b/patrickstar/ops/fp16_cpu_adam.py
@@ -504,9 +504,7 @@ class FP16Adam(torch.optim.Optimizer):
         mgr = PatrickStarManager()
 
         if mgr.is_warmup_training():
-            logger.info('----------- SHOW ACCESS INFO -----------')
-            for _, chunk in self.client.chunk_list.generate_chunk():
-                chunk.display_access_mom_info()
+            self.client.chunk_list.display_access_info()
         mgr.reset_metronome()
 
         if self.loss_scaler:


### PR DESCRIPTION
The early return will reduce the total number of moments. For GPT3_8B model, it shrinks from 5570 to 3470.