### PR TITLE
Jiaruifang/adam no memtrace

### DIFF
--- a/patrickstar/manager/manager.py
+++ b/patrickstar/manager/manager.py
@@ -206,21 +206,6 @@ class RuntimeMemTracer(object):
             assert (
                 len(self.gpu_sys_used_list) - 1 == cur_mom
             ), f"{len(self.gpu_sys_used_list) - 1} vs {cur_mom}"
-        # else:
-        #     # If the available chunk memory is smaller than current chunk memory,
-        #     # we need to move chunks from compute device to make room.
-        #     next_mom = metronome.next_moment()
-        #     cur_mom = metronome.moment()
-        #     gpu_next_mom_ava_chunk_mem = (
-        #         self._overall_gpu_mem - self.gpu_sys_used_list[next_mom]
-        #     )
-        #     gpu_cur_mom_used_chunk_mem = chunk_list.get_chunk_memory_used(
-        #         gpu_device
-        #     )
-        #     if gpu_next_mom_ava_chunk_mem < gpu_cur_mom_used_chunk_mem:
-        #         offload_size = gpu_cur_mom_used_chunk_mem - gpu_next_mom_ava_chunk_mem
-        #         # NOTE() Here will lead to GPU <-> CPU memory movement.
-        #         chunk_list.make_room(offload_size, gpu_device)
 
         # The async memory monitor maybe time-consuming.
         # We only run it during warmup.

--- a/patrickstar/ops/fp16_cpu_adam.py
+++ b/patrickstar/ops/fp16_cpu_adam.py
@@ -506,8 +506,6 @@ class FP16Adam(torch.optim.Optimizer):
         if profiler.started():
             profiler.stage_convert_time.append((time.time(), TrainingStage.ADAM))
         self.client.metronome.set_training_phase(TrainingStage.ADAM)
-        self.client.trigger_memory_tracing()
-        self.client.adjust_chunk_layout()
 
         loss = None
         if closure is not None:

--- a/patrickstar/runtime/__init__.py
+++ b/patrickstar/runtime/__init__.py
@@ -80,12 +80,5 @@ def initialize_engine(model_func, local_rank, config=None, client=None):
             model = model_func()
 
     engine = PatrickStarEngine(model=model, client=client, config=config)
-
-    # 开启预热优化
-    mgr = RuntimeMemTracer(local_rank=local_rank)
-    mgr.start_train(
-        param_fp16_chunk_size=client.param_fp16_chunks_max_mem_usage(),
-        chunk_size=client.default_chunk_size,
-    )
-
+    client.start_mem_tracer()
     return (engine, engine.optimizer)

--- a/patrickstar/runtime/engine.py
+++ b/patrickstar/runtime/engine.py
@@ -151,7 +151,6 @@ class PatrickStarEngine(torch.nn.Module):
 
     def _reset_before_forward(self):
         self.client.mem_tracer.reset_memory_stats(self.client.metronome)
-
         self.client.metronome.reset()
         for param_fp16 in self.client.chunk_based_param_fp16:
             param_fp16.ps_attr.fwd_used_cnt = 0


### PR DESCRIPTION
Eliminate a potential warmup bug.
If the grad overflow happens during warmup, the ADAM will not be executed. 
Therefore the mem stats array has no adam part. But the 2nd iteration will be viewed as a non-warmup iteration.
The 2nd iteration will access adam part in mem stats array. Out of range error will be thrown.
Actually, mem stats do not need adam part. This is fixed in this MR.