### PR TITLE
Add cuda event to enable async move

### DIFF
--- a/patrickstar/manager/cuda_context.py
+++ b/patrickstar/manager/cuda_context.py
@@ -33,4 +33,5 @@ import torch
 
 class CUDAContext(metaclass=SingletonMeta):
     def __init__(self):
+        self.compute_stream = torch.cuda.current_stream()
         self.copy_stream = torch.cuda.Stream()


### PR DESCRIPTION
This MR introduce the `compute_finished_event` for each chunk to both enable async move and prevent the error solved by #243 .

This MR would reduce the running time of GPT_DS_20B model from 31s to 23s.

before:
```bash
LOSS of step 4: 30.3125
After step 4. using patrickstar, gradient checkpoint: True, fp16 True
MA 24654.34 MB         Max_MA 26702.34 MB         CA 35922.0 MB         Max_CA 35922 MB 
CPU Virtual Memory: used = 382.98 GB, percent = 38.0%
Step 4 elaspe 31.289400815963745 s, 85.71122079282361 Tflops
[2021-11-25 08:37:21,197] [INFO] ------------- PROFILE RESULTS ----------------
CLIENT_access_dist ........... 14.548331499099731, 46.51147359937334 %
CLIENT_release ............... 0.041019439697265625, 0.13114043948328497 %
CHUNK_LIST_prepare_device .... 2.9876492023468018, 9.551608513164625 %
chunk_cpu_gpu_move ........... 11.527435779571533, 36.85357492460156 %
chunk_gpu_cpu_move ........... 6.301123380661011, 20.14488972733021 %
CHUNK_LIST_chunk_move ........ 6.302181959152222, 20.14827403607722 %
FWD .......................... 6.604133605957031, 21.113622952516074 %
CLIENT_release_dist .......... 0.010951519012451172, 0.03501235089757051 %
CHUNK_LIST_make_room ......... 3.338402271270752, 10.672977111767498 %
BWD .......................... 12.72333574295044, 40.67690473927011 %
ADAM_prepare_data_grad_copy .. 2.224769115447998, 7.112656869570509 %
ADAM_prepare_data ............ 2.2559614181518555, 7.212379642852373 %
ADAM_compute ................. 6.490498304367065, 20.750327317536517 %
ADAM_param_fp32_to_fp16 ...... 3.126406192779541, 9.995218977886317 %
ADAM_release_data ............ 0.02622246742248535, 0.08383405350000638 %
CLIENT_access ................ 0.024319887161254883, 0.07775144453578352 %
ADAM ......................... 11.951547145843506, 38.20947230821382 %
TOTAL ........................ 31.279016494750977
------------- DATA MOVE RESULTS --------------
chunk_cpu_gpu_move: 456704.0 MB, 446 times, 39618.87177106229 MB/s
chunk_gpu_cpu_move: 434176.0 MB, 424 times, 68904.53872599038 MB/s
ADAM_prepare_data_grad_copy: 195130.4687690735 MB, 2045 times, 87708.1884201635 MB/s
ADAM_param_fp32_to_fp16: 390260.937538147 MB, 2045 times, 124827.329999364 MB/s
[2021-11-25 08:37:21,198] [INFO] End Step 4 with patrickstar.
```

After:

```bash
LOSS of step 4: 30.3125
After step 4. using patrickstar, gradient checkpoint: True, fp16 True
MA 24654.34 MB         Max_MA 26702.34 MB         CA 37970.0 MB         Max_CA 37970 MB 
CPU Virtual Memory: used = 382.98 GB, percent = 38.0%
Step 4 elaspe 23.478252172470093 s, 114.22710353869039 Tflops
[2021-11-25 08:25:22,306] [INFO] ------------- PROFILE RESULTS ----------------
CLIENT_access_dist ........... 6.679223299026489, 28.460310886918137 %
CLIENT_release ............... 0.08199810981750488, 0.3493956696860223 %
CHUNK_LIST_prepare_device .... 1.3309521675109863, 5.671215164868228 %
chunk_cpu_gpu_move ........... 5.3133323192596436, 22.64022070854851 %
chunk_gpu_cpu_move ........... 2.7368438243865967, 11.661749069287348 %
CHUNK_LIST_chunk_move ........ 2.737934112548828, 11.666394810066514 %
FWD .......................... 3.5384573936462402, 15.077441339319217 %
CLIENT_release_dist .......... 0.015672922134399414, 0.0667826506888131 %
CHUNK_LIST_make_room ......... 1.430833101272583, 6.096809923310432 %
BWD .......................... 9.48042106628418, 40.39627345961946 %
ADAM_prepare_data_grad_copy .. 2.0144152641296387, 8.583465787232916 %
ADAM_prepare_data ............ 2.051557779312134, 8.741730825230666 %
ADAM_compute ................. 4.896666526794434, 20.86479900775998 %
ADAM_param_fp32_to_fp16 ...... 3.3797430992126465, 14.401156394266353 %
ADAM_release_data ............ 0.059040069580078125, 0.2515709776134014 %
CLIENT_access ................ 0.029054641723632812, 0.12380243916731096 %
ADAM ......................... 10.4496750831604, 44.52628520106132 %
TOTAL ........................ 23.46855354309082
------------- DATA MOVE RESULTS --------------
chunk_cpu_gpu_move: 456704.0 MB, 446 times, 85954.3451375232 MB/s
chunk_gpu_cpu_move: 434176.0 MB, 424 times, 158641.13112019133 MB/s
ADAM_prepare_data_grad_copy: 195130.4687690735 MB, 2045 times, 96867.05231226631 MB/s
ADAM_param_fp32_to_fp16: 390260.937538147 MB, 2045 times, 115470.59231486061 MB/s
[2021-11-25 08:25:22,306] [INFO] End Step 4 with patrickstar.
```