### PR TITLE
Add cuda event to enable async move

### DIFF
--- a/patrickstar/core/memory_cache.py
+++ b/patrickstar/core/memory_cache.py
@@ -83,9 +83,8 @@ class MemoryCache(object):
                 break
         if i == -1:
             return self._new_mem(size, data_type, device_type, pin_memory)
-        new_tensor_ref = tensors[i]
         # delete the reference to tensors[i] in MemoryCache
-        tensors.pop(i)
+        new_tensor_ref = tensors.pop(i)
         return new_tensor_ref
 
     def push(self, payload):

--- a/patrickstar/manager/cuda_context.py
+++ b/patrickstar/manager/cuda_context.py
@@ -33,4 +33,5 @@ import torch
 
 class CUDAContext(metaclass=SingletonMeta):
     def __init__(self):
+        self.compute_stream = torch.cuda.current_stream()
         self.copy_stream = torch.cuda.Stream()


### PR DESCRIPTION
same as #248 , rebase upon develop branch.

The current async copy will reduce the GPT_DS_20B from 33s to 26.7s.

Before:

```bash
LOSS of step 4: 36.15625
After step 4. using patrickstar, gradient checkpoint: True, fp16 True
MA 25678.34 MB         Max_MA 25678.34 MB         CA 37090.0 MB         Max_CA 37090 MB 
CPU Virtual Memory: used = 379.18 GB, percent = 37.7%
Step 4 elaspe 32.97649335861206 s, 81.32619537946832 Tflops
CLIENT_access_dist ........... 12.408604621887207, 37.63114522576192 %
CLIENT_release ............... 0.05572009086608887, 0.16898038863096113 %
chunk_gpu_cpu_move ........... 8.990646839141846, 27.265623104834514 %
CHUNK_LIST_chunk_move ........ 8.992210149765015, 27.270364102786022 %
CHUNK_LIST_prepare_device .... 8.011608600616455, 24.29652776670617 %
chunk_cpu_gpu_move ........... 4.352960109710693, 13.201071276099574 %
FWD .......................... 7.912651300430298, 23.996423391723816 %
CLIENT_release_dist .......... 0.014462709426879883, 0.043860557684377154 %
CHUNK_LIST_make_room ......... 1.0061476230621338, 3.05130902915721 %
BWD .......................... 13.260764837265015, 40.21546197995484 %
ADAM_prepare_data_grad_copy .. 2.3101890087127686, 7.006030148828074 %
CLIENT_access ................ 0.026372671127319336, 0.07997948580236691 %
ADAM_prepare_data ............ 2.3438620567321777, 7.108149234641909 %
ADAM_compute ................. 6.187630891799927, 18.765013777779657 %
ADAM_param_fp32_to_fp16 ...... 3.1782169342041016, 9.638468357598502 %
ADAM_release_data ............ 0.034723520278930664, 0.1053048166319443 %
ADAM ......................... 11.800878286361694, 35.788114628321345 %
TOTAL ........................ 32.97429442405701
------------- DATA MOVE RESULTS --------------
chunk_cpu_gpu_move: 456704.0 MB, 446 times, 104918.0301425628 MB/s
chunk_gpu_cpu_move: 434176.0 MB, 424 times, 48291.964723802004 MB/s
ADAM_prepare_data_grad_copy: 195130.4687690735 MB, 2045 times, 84465.15329834406 MB/s
ADAM_param_fp32_to_fp16: 390260.937538147 MB, 2045 times, 122792.4165081819 MB/s
******************** LOSS ********************
[1.125, 51.21875, 107.125, 74.75, 36.15625]
```

After:

```bash
LOSS of step 4: 36.15625
After step 4. using patrickstar, gradient checkpoint: True, fp16 True
MA 25678.34 MB         Max_MA 25678.34 MB         CA 37842.0 MB         Max_CA 37842 MB 
CPU Virtual Memory: used = 379.21 GB, percent = 37.7%
Step 4 elaspe 26.617305755615234 s, 100.75598058028302 Tflops
CLIENT_access_dist ........... 8.18982458114624, 30.771282427021944 %
CLIENT_release ............... 0.05392098426818848, 0.20259503963969056 %
chunk_gpu_cpu_move ........... 4.527429819107056, 17.010721078566217 %
CHUNK_LIST_chunk_move ........ 4.5287909507751465, 17.01583520116606 %
CHUNK_LIST_prepare_device .... 3.9929306507110596, 15.002469899953105 %
chunk_cpu_gpu_move ........... 4.155442953109741, 15.613070518492306 %
FWD .......................... 4.422711372375488, 16.617266876004393 %
CLIENT_release_dist .......... 0.014034271240234375, 0.05273037532267167 %
CHUNK_LIST_make_room ......... 0.5604538917541504, 2.1057697658375036 %
BWD .......................... 12.2871732711792, 46.16607782144863 %
ADAM_prepare_data_grad_copy .. 1.8125267028808594, 6.810130122843214 %
CLIENT_access ................ 0.026548147201538086, 0.09974823359871589 %
ADAM_prepare_data ............ 1.8462865352630615, 6.936974516960416 %
ADAM_compute ................. 4.870876312255859, 18.301138099656182 %
ADAM_param_fp32_to_fp16 ...... 3.100311517715454, 11.64866968493959 %
ADAM_release_data ............ 0.034404754638671875, 0.12926753330665283 %
ADAM ......................... 9.90527057647705, 37.21665530254698 %
TOTAL ........................ 26.61515522003174
------------- DATA MOVE RESULTS --------------
chunk_cpu_gpu_move: 456704.0 MB, 446 times, 109905.01016461407 MB/s
chunk_gpu_cpu_move: 434176.0 MB, 424 times, 95899.00171785158 MB/s
ADAM_prepare_data_grad_copy: 195130.4687690735 MB, 2045 times, 107656.6036014421 MB/s
ADAM_param_fp32_to_fp16: 390260.937538147 MB, 2045 times, 125877.97558669878 MB/s
******************** LOSS ********************
[1.125, 51.21875, 107.125, 74.75, 36.15625]
```

One caveat is that we need to put the gpu copy buffer in the copy stream, otherwise it will mysterious nan...