### PR TITLE
Improve Memory Saving Communication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ For some detail explanation of the above example, please check the guide [here](
 
 For more examples, please check [here](./examples).
 
-A quick-start benchmark script is [here](./examples/run_bert.sh). It involves some optimization techniques for patricksatr. For more optimization tricks using PatrickStar see [Optimization Options](./doc/optimization_options.md).
+A quick-start benchmark script is [here](./examples/run_bert.sh). It is executed with random generated data, therefore you do not need to prepare the real data. It also demostrated all of the optimization techniques for patricksatr. For more optimization tricks using PatrickStar see [Optimization Options](./doc/optimization_options.md).
+
 ### Inside PatrickStar
 
 See [this doc](./INSIDE.md) for the idea behind PatrickStar.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ For some detail explanation of the above example, please check the guide [here](
 
 For more examples, please check [here](./examples).
 
+For more optimization tricks using PatrickStar see [Optimization Options](./doc/optimization_options.md).
 ### Inside PatrickStar
 
 See [this doc](./INSIDE.md) for the idea behind PatrickStar.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ For some detail explanation of the above example, please check the guide [here](
 
 For more examples, please check [here](./examples).
 
-For more optimization tricks using PatrickStar see [Optimization Options](./doc/optimization_options.md).
+A quick-start benchmark script is [here](./examples/run_bert.sh). It involves some optimization techniques for patricksatr. For more optimization tricks using PatrickStar see [Optimization Options](./doc/optimization_options.md).
 ### Inside PatrickStar
 
 See [this doc](./INSIDE.md) for the idea behind PatrickStar.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ For more examples, please check [here](./examples).
 
 See [this doc](./INSIDE.md) for the idea behind PatrickStar.
 
+### Limitations
+
+1. PatrickStar currently is not evaluated on DNN with parameters shared in different layers. For example, be careful to use it with tie-weight. But you can still label the tied weight to be managed by PyTorch, and make the remaining layers managed by PatrickStar chunk-based memory management.
+
 ### License
 BSD 3-Clause License
 

--- a/doc/optimization_options.md
+++ b/doc/optimization_options.md
@@ -1,0 +1,31 @@
+This page explains the optimization options for PatrickStar.
+
+1. Memory Saving Communication.
+`--with_mem_saving_com`
+Use one-to-all communication to replace the original collective communication. More specifically, reduce scatter is replaced with Nx reduce. all gather is replaced with Nx bcast. In this way, we do not need to keep a Nx chunk buffer for distributed training, therefore save the GPU memory. Details in MR #250. It is suitable for training extremely large model with computing cluster with high-quality intra-GPU communication bandwidth, i.e. 40B model on a node of SuperPod.
+
+2. Memory Allocation Caching.
+`--with_mem_cache`
+Use a cache to allocate and release chunk memory. The cache is a size-limited queue, whose capacity is default as 2. It is helpful for Memory Saving Communication in distributed training. It avoid frequent release and allocate memory for remote chunks. See detail in #241.
+
+2. Hybrid ADAM:
+`--use_hybrid_adam`
+Place Optimizer States (OS) on both CPU and GPU. Part of ADAM computation is conducted on CPU and the rest of computation is on GPU. On the contrary, Zero-Offload does ADAM on CPU only. This technique is able to accelerate ADAM computation for relative small model.
+
+3. Activation Offload.
+`--with_activation_offload`
+Offload activation to CPU. Must used in combination with activation checkpointing (a.k.a gradient checkpoint in PyTorch).
+
+4. Asyn Monitoring Memory with the Runtime Memory Tracer.
+`--with_async_mem_monitor`
+Async Sampling memory usage with an independent thread. It will bring a more accurate runtime
+memory usage statistics. If you turn off this flag, memory usage sampling will triggered at the exact moment before or after operators (submodule in PyTorch) computing.
+
+
+5. Static Partion.
+`--with_static_partition`
+PatirckStar is famous for dynamic partition model data. With help of this flag you can static partition model data between CPU and GPU. The max GPU used by chunks is `warmup_gpu_chunk_mem_ratio` * gpu_size. It is still better than Zero-Offload, which alway put all param and grad in GPU, to avoid OOM. It will lead to lower computing efficient than the default dynamic partition. But it is helpful to aggressively avoid OOM.
+
+6. Release Remote Chunk After Initialization.
+`release_after_init`
+The is a computing efficient irrelevant option used for distributed training. It allocates memory for remote chunks but release it immediately. In this way, we can make sure the model parameter is randomly initialized the same as a serial version. Solve the problem with random seed. It is used in combination with the `--res_check` option to check the correctness of distributed training.

--- a/patrickstar/core/chunk_data.py
+++ b/patrickstar/core/chunk_data.py
@@ -204,6 +204,8 @@ class Chunk(object):
         # Distributed training need to fix the chunk on the compute device.
         if self._state_dict[TensorState.COMPUTE] > 0:
             return ChunkState.COMPUTE
+        elif self._state_dict[TensorState.HOLD_AND_TOUCHED]:
+            return ChunkState.HOHOLD_AND_TOUCHEDLD
         elif self._state_dict[TensorState.HOLD] > 0:
             return ChunkState.HOLD
         elif self._state_dict[TensorState.HOLD_AFTER_FWD] > 0:

--- a/patrickstar/core/chunk_data.py
+++ b/patrickstar/core/chunk_data.py
@@ -205,7 +205,7 @@ class Chunk(object):
         # Distributed training need to fix the chunk on the compute device.
         if self._state_dict[TensorState.COMPUTE] > 0:
             return ChunkState.COMPUTE
-        elif self._state_dict[TensorState.HOLD_AND_TOUCHED]:
+        elif self._state_dict[TensorState.HOLD_AND_TOUCHED] > 0:
             return ChunkState.HOLD_AND_TOUCHED
         elif self._state_dict[TensorState.HOLD] > 0:
             return ChunkState.HOLD

--- a/patrickstar/core/chunk_data.py
+++ b/patrickstar/core/chunk_data.py
@@ -269,7 +269,7 @@ class Chunk(object):
 
         cuda_ctx = CUDAContext()
         self.compute_finish_event.synchronize()
-        with torch.cuda.stream(cuda_ctx.copy_stream):
+        with torch.cuda.stream(cuda_ctx.compute_stream):
             if self.with_mem_cache:
                 payload_numel = self.payload.numel()
                 if target_device.type == "cpu":

--- a/patrickstar/core/chunk_data.py
+++ b/patrickstar/core/chunk_data.py
@@ -206,7 +206,7 @@ class Chunk(object):
         if self._state_dict[TensorState.COMPUTE] > 0:
             return ChunkState.COMPUTE
         elif self._state_dict[TensorState.HOLD_AND_TOUCHED]:
-            return ChunkState.HOHOLD_AND_TOUCHEDLD
+            return ChunkState.HOLD_AND_TOUCHED
         elif self._state_dict[TensorState.HOLD] > 0:
             return ChunkState.HOLD
         elif self._state_dict[TensorState.HOLD_AFTER_FWD] > 0:

--- a/patrickstar/core/chunk_data.py
+++ b/patrickstar/core/chunk_data.py
@@ -78,6 +78,7 @@ class Chunk(object):
             TensorState.HOLD: 0,
             TensorState.HOLD_AFTER_FWD: 0,
             TensorState.HOLD_AFTER_BWD: 0,
+            TensorState.HOLD_AND_TOUCHED: 0,
             TensorState.FREE: 0,
         }
         # the number of tensors that are not used in the forward calculation

--- a/patrickstar/core/chunk_data.py
+++ b/patrickstar/core/chunk_data.py
@@ -78,7 +78,6 @@ class Chunk(object):
             TensorState.HOLD: 0,
             TensorState.HOLD_AFTER_FWD: 0,
             TensorState.HOLD_AFTER_BWD: 0,
-            TensorState.HOLD_AND_TOUCHED: 0,
             TensorState.FREE: 0,
         }
         # the number of tensors that are not used in the forward calculation
@@ -205,8 +204,6 @@ class Chunk(object):
         # Distributed training need to fix the chunk on the compute device.
         if self._state_dict[TensorState.COMPUTE] > 0:
             return ChunkState.COMPUTE
-        elif self._state_dict[TensorState.HOLD_AND_TOUCHED] > 0:
-            return ChunkState.HOLD_AND_TOUCHED
         elif self._state_dict[TensorState.HOLD] > 0:
             return ChunkState.HOLD
         elif self._state_dict[TensorState.HOLD_AFTER_FWD] > 0:

--- a/patrickstar/core/client.py
+++ b/patrickstar/core/client.py
@@ -741,19 +741,11 @@ class PatrickStarClient(object):
                                 "CLIENT_release_dist_reduce"
                             )
                         # release chunk payload, only its belonging gpu owns it.
-                        if rank != target_rank:
-                            self.chunk_list[chunk_id].release_payload()
-                            self.set_all_tensors_state_in_chunk(
-                                chunk_id, TensorState.FREE
-                            )
-                        else:
+                        if rank == target_rank:
                             self.chunk_list[chunk_id].payload /= world_size
-                    else:
-                        if target_rank != rank:
-                            self.chunk_list[chunk_id].release_payload()
-                            self.set_all_tensors_state_in_chunk(
-                                chunk_id, TensorState.FREE
-                            )
+                    if target_rank != rank:
+                        self.chunk_list[chunk_id].release_payload()
+                        self.set_all_tensors_state_in_chunk(chunk_id, TensorState.FREE)
             else:
                 all_chunks_ready = True
                 for i in chunk_id_list:

--- a/patrickstar/core/client.py
+++ b/patrickstar/core/client.py
@@ -106,7 +106,10 @@ class PatrickStarClient(object):
         # for post backward hook
         self.grad_accs = []
 
-        self.visited_chunk = {{}}
+        self.visited_chunk = {TrainingStage.FWD: {}, TrainingStage.BWD: {}}
+
+    def reset_visited_chunk(self):
+        self.visited_chunk = {TrainingStage.FWD: {}, TrainingStage.BWD: {}}
 
     # expose APIs from metrome ti client
     def training_stage(self):

--- a/patrickstar/core/client.py
+++ b/patrickstar/core/client.py
@@ -356,8 +356,6 @@ class PatrickStarClient(object):
             ):
                 return
             self.visited_chunk[chunk_id] = 1
-            if rank == 0:
-                print(f"reduce chunk_id {chunk_id} on rank {rank} {training_stage}")
             # Find the source rank to bcast its local chunk, which owned by the gpu.
             src_rank = -1
             for cur_rank, cur_chunk_id in enumerate(chunk_id_list):
@@ -387,12 +385,8 @@ class PatrickStarClient(object):
                 global_timer.my_timer.finish_profile(
                     "CLIENT_fetch_remote_chunks_broadcast"
                 )
-            # set the chunk as HOLD_AND_TOUCHED, therefore it can be offloaded to CPU.
+            # set the chunk as HOLD, therefore it can be offloaded to CPU.
             self.set_all_tensors_state_in_chunk(chunk_id, TensorState.HOLD)
-            if rank == 0:
-                print(
-                    f"state of chunk id {chunk_id} {self.chunk_list[chunk_id].get_state()}"
-                )
         else:
             # During FWD, when there are param in the chunk group being visited for
             # the first time, collect the chunk group to local.

--- a/patrickstar/core/client.py
+++ b/patrickstar/core/client.py
@@ -347,7 +347,7 @@ class PatrickStarClient(object):
 
             # check the chunk_id is the first to be visited.
             # local chunk as HOLD, remote chunk as RELEASED
-            if (
+            if not (
                 self.chunk_list[chunk_id].get_state() == ChunkState.HOLD
                 or self.chunk_list[chunk_id].get_state() == ChunkState.RELEASED
             ):

--- a/patrickstar/core/client.py
+++ b/patrickstar/core/client.py
@@ -106,6 +106,8 @@ class PatrickStarClient(object):
         # for post backward hook
         self.grad_accs = []
 
+        self.visited_chunk = {}
+
     # expose APIs from metrome ti client
     def training_stage(self):
         return self.mem_tracer.metronome.training_stage()
@@ -350,10 +352,10 @@ class PatrickStarClient(object):
             # local chunk as HOLD, remote chunk as RELEASED
             if not (
                 self.chunk_list[chunk_id].is_dummy()
-                or self.chunk_list[chunk_id].get_state() == ChunkState.HOLD
-                or self.chunk_list[chunk_id].get_state() == ChunkState.RELEASED
+                or chunk_id not in self.visited_chunk
             ):
                 return
+            self.visited_chunk[chunk_id] = 1
             if rank == 0:
                 print(f"reduce chunk_id {chunk_id} on rank {rank} {training_stage}")
             # Find the source rank to bcast its local chunk, which owned by the gpu.

--- a/patrickstar/core/client.py
+++ b/patrickstar/core/client.py
@@ -323,6 +323,7 @@ class PatrickStarClient(object):
 
     def _fetch_remote_chunks(
         self,
+        chunk_id,
         chunk_id_list,
         local_chunk_id,
         compute_device,
@@ -332,59 +333,72 @@ class PatrickStarClient(object):
         r"""Fetch the remote chunks to local.
 
         Args:
+            chunk_id: the id of accessed chunk
             chunk_id_list: list of int. The id of the chunks in a same comm group.
             local_chunk_id: int. The id of the local chunk in the comm group.
             compute_device: :class:`torch.device`.
+            with_mem_saving_comm: using the memory saving communication pattern or not.
             param_name: str.
         """
         rank = get_rank()
-        # During FWD, when there are param in the chunk group being visited for
-        # the first time, collect the chunk group to local.
-        # How can we determine if a chunk group is being visited for the first time,
-        # so that we can trigger the correct allgather?
-        # When the first param is visited, the remote chunk should be of state
-        # RELEASED, therefore, we do the allgather when the state of chunks are
-        # changing form HOLD_AFTER_FWD(HOLD_ADFTER_BWD) to RELEASED.
-        has_released_chunk = False
-        for i in chunk_id_list:
-            if self.chunk_list[i].get_state() == ChunkState.RELEASED:
-                has_released_chunk = True
-                break
-        if not has_released_chunk:
-            return
-
-        if self._time_profile:
-            global_timer.my_timer.start_profile("CLIENT_fetch_remote_chunks")
-
-        logger.debug(
-            f"rank {rank} fetch {param_name} remote chunks {chunk_id_list} local chunk {local_chunk_id}"
-        )
-
         if with_mem_saving_comm:
             # Use memory saving communication pattern.
-            # Bcast chunk one by one, so that the bcasted chunks can be moved to CPU
-            for cur_rank, chunk_id in enumerate(chunk_id_list):
-                if chunk_id == local_chunk_id:
-                    self.chunk_list.access_chunk(local_chunk_id, compute_device)
-                else:
-                    self.chunk_list.try_best_allocate_payload(
-                        self.chunk_list[chunk_id], compute_device
-                    )
-                if self._time_profile:
-                    global_timer.my_timer.start_profile(
-                        "CLIENT_fetch_remote_chunks_broadcast"
-                    )
-                torch.distributed.broadcast(
-                    self.chunk_list[chunk_id].payload,
-                    src=cur_rank,
-                    async_op=False,
+            # Bcast chunk from the src gpu to the others.
+
+            # Find the source rank to bcast its local chunk, which owned by the gpu.
+            src_rank = -1
+            for cur_rank, cur_chunk_id in enumerate(chunk_id_list):
+                if chunk_id == cur_chunk_id:
+                    src_rank = cur_rank
+
+            # If the gpu owns the chunk (local rank), access it.
+            # If the gpu do not own the chunk (remote chunk), allocate memory.
+            if src_rank == rank:
+                self.chunk_list.access_chunk(chunk_id, compute_device)
+            else:
+                self.chunk_list.try_best_allocate_payload(
+                    self.chunk_list[chunk_id], compute_device
                 )
-                if self._time_profile:
-                    global_timer.my_timer.finish_profile(
-                        "CLIENT_fetch_remote_chunks_broadcast"
-                    )
-                self.set_all_tensors_state_in_chunk(chunk_id, TensorState.HOLD)
+            if self._time_profile:
+                global_timer.my_timer.start_profile(
+                    "CLIENT_fetch_remote_chunks_broadcast"
+                )
+
+            # Do Bcast from gpu owns chunk to gpu do not own it.
+            torch.distributed.broadcast(
+                self.chunk_list[chunk_id].payload,
+                src=src_rank,
+                async_op=False,
+            )
+            if self._time_profile:
+                global_timer.my_timer.finish_profile(
+                    "CLIENT_fetch_remote_chunks_broadcast"
+                )
+            # set the chunk as HOLD, therefore it can be offloaded to CPU.
+            self.set_all_tensors_state_in_chunk(chunk_id, TensorState.HOLD)
         else:
+            # During FWD, when there are param in the chunk group being visited for
+            # the first time, collect the chunk group to local.
+            # How can we determine if a chunk group is being visited for the first time,
+            # so that we can trigger the correct allgather?
+            # When the first param is visited, the remote chunk should be of state
+            # RELEASED, therefore, we do the allgather when the state of chunks are
+            # changing form HOLD_AFTER_FWD(HOLD_ADFTER_BWD) to RELEASED.
+            has_released_chunk = False
+            for i in chunk_id_list:
+                if self.chunk_list[i].get_state() == ChunkState.RELEASED:
+                    has_released_chunk = True
+                    break
+            if not has_released_chunk:
+                return
+
+            if self._time_profile:
+                global_timer.my_timer.start_profile("CLIENT_fetch_remote_chunks")
+
+            logger.debug(
+                f"rank {rank} fetch {param_name} remote chunks {chunk_id_list} local chunk {local_chunk_id}"
+            )
+
             # Use collective communication to achieve the most efficient communication.
             # However, it is memory consumping. world_size chunks on GPU simutaneously.
             self.chunk_list.access_chunk(local_chunk_id, compute_device)
@@ -430,7 +444,7 @@ class PatrickStarClient(object):
                 global_timer.data_move_cnter.update(
                     "CLIENT_fetch_remote_chunks_allgather", comm_data_amount
                 )
-        global_timer.my_timer.finish_profile("CLIENT_fetch_remote_chunks")
+            global_timer.my_timer.finish_profile("CLIENT_fetch_remote_chunks")
 
     def _access_tensor_in_chunk(self, param, access_type, compute_device, chunk_id):
         self.chunk_list.access_chunk(chunk_id, compute_device)
@@ -509,22 +523,15 @@ class PatrickStarClient(object):
                 f"local_chunk_id {local_chunk_id} chunk_id_list {chunk_id_list}"
             )
 
-            # # 1.1 Move the local chunk to compute device.
-            # self.chunk_list.access_chunk(local_chunk_id, compute_device)
-
-            # # Prevent the local chunk being moved to other devices during _fetch_remote_chunks.
-            # # Because its state is HOLD, pin.
-            # self.chunk_list[local_chunk_id].pin()
-
             # 1.2 Fetch the remote chunks to local.
             self._fetch_remote_chunks(
+                chunk_id,
                 chunk_id_list,
                 local_chunk_id,
                 compute_device,
                 with_mem_saving_comm,
                 param.ps_attr.name,
             )
-            # self.chunk_list[local_chunk_id].unpin()
         else:
             local_chunk_id = chunk_id
 
@@ -685,59 +692,81 @@ class PatrickStarClient(object):
         #     BWD: All non-dummy chunks are of state HOLD_AFTER_BWD.
         world_size = get_world_size()
         if world_size > 1:
-            all_chunks_ready = True
-            for i in chunk_id_list:
+            if with_mem_saving_comm:
+                # Check if the chunk_id is ready to reduced or removed.
+                chunk_ready = False
                 if training_stage == TrainingStage.FWD:
                     if (
-                        not self.chunk_list[i].all_tensor_state(
+                        self.chunk_list[chunk_id].all_tensor_state(
                             TensorState.HOLD_AFTER_FWD
                         )
-                        and not self.chunk_list[i].is_dummy()
+                        or self.chunk_list[chunk_id].is_dummy()
                     ):
-                        all_chunks_ready = False
+                        chunk_ready = True
                 elif training_stage == TrainingStage.BWD:
                     if (
-                        not self.chunk_list[i].all_tensor_state(
+                        self.chunk_list[chunk_id].all_tensor_state(
                             TensorState.HOLD_AFTER_BWD
                         )
-                        and not self.chunk_list[i].is_dummy()
+                        or self.chunk_list[chunk_id].is_dummy()
                     ):
-                        all_chunks_ready = False
-
-            if all_chunks_ready:
-                if with_mem_saving_comm:
+                        chunk_ready = True
+                if chunk_ready:
+                    target_rank = -1
+                    for cur_rank, cur_chunk_id in enumerate(chunk_id_list):
+                        if cur_chunk_id == chunk_id:
+                            target_rank = cur_rank
+                            break
                     if do_allreduce:
-                        for cur_rank, cur_chunk_id in enumerate(chunk_id_list):
-                            self.chunk_list.access_chunk(cur_chunk_id, self.device)
-                            if self._time_profile:
-                                global_timer.my_timer.start_profile(
-                                    "CLIENT_release_dist_reduce"
-                                )
-                            torch.distributed.reduce(
-                                self.chunk_list[cur_chunk_id].payload,
-                                cur_rank,
-                                op=torch.distributed.ReduceOp.SUM,
-                                async_op=False,
+                        self.chunk_list.access_chunk(chunk_id, self.device)
+                        if self._time_profile:
+                            global_timer.my_timer.start_profile(
+                                "CLIENT_release_dist_reduce"
                             )
-                            if self._time_profile:
-                                global_timer.my_timer.finish_profile(
-                                    "CLIENT_release_dist_reduce"
-                                )
-                            if cur_chunk_id != local_chunk_id:
-                                self.chunk_list[cur_chunk_id].release_payload()
-                                self.set_all_tensors_state_in_chunk(
-                                    cur_chunk_id, TensorState.FREE
-                                )
-                            else:
-                                self.chunk_list[local_chunk_id].payload /= world_size
+                        torch.distributed.reduce(
+                            self.chunk_list[chunk_id].payload,
+                            target_rank,
+                            op=torch.distributed.ReduceOp.SUM,
+                            async_op=False,
+                        )
+                        if self._time_profile:
+                            global_timer.my_timer.finish_profile(
+                                "CLIENT_release_dist_reduce"
+                            )
+                        if rank != target_rank:
+                            self.chunk_list[chunk_id].release_payload()
+                            self.set_all_tensors_state_in_chunk(
+                                cur_chunk_id, TensorState.FREE
+                            )
+                        else:
+                            self.chunk_list[chunk_id].payload /= world_size
                     else:
-                        for cur_rank, cur_chunk_id in enumerate(chunk_id_list):
-                            if cur_chunk_id != local_chunk_id:
-                                self.chunk_list[cur_chunk_id].release_payload()
-                                self.set_all_tensors_state_in_chunk(
-                                    cur_chunk_id, TensorState.FREE
-                                )
-                else:
+                        if target_rank != rank:
+                            self.chunk_list[chunk_id].release_payload()
+                            self.set_all_tensors_state_in_chunk(
+                                cur_chunk_id, TensorState.FREE
+                            )
+            else:
+                all_chunks_ready = True
+                for i in chunk_id_list:
+                    if training_stage == TrainingStage.FWD:
+                        if (
+                            not self.chunk_list[i].all_tensor_state(
+                                TensorState.HOLD_AFTER_FWD
+                            )
+                            and not self.chunk_list[i].is_dummy()
+                        ):
+                            all_chunks_ready = False
+                    elif training_stage == TrainingStage.BWD:
+                        if (
+                            not self.chunk_list[i].all_tensor_state(
+                                TensorState.HOLD_AFTER_BWD
+                            )
+                            and not self.chunk_list[i].is_dummy()
+                        ):
+                            all_chunks_ready = False
+
+                if all_chunks_ready:
                     if do_allreduce:
                         if self._time_profile:
                             global_timer.my_timer.start_profile(

--- a/patrickstar/core/client.py
+++ b/patrickstar/core/client.py
@@ -106,7 +106,7 @@ class PatrickStarClient(object):
         # for post backward hook
         self.grad_accs = []
 
-        self.visited_chunk = {}
+        self.visited_chunk = {{}}
 
     # expose APIs from metrome ti client
     def training_stage(self):
@@ -350,9 +350,9 @@ class PatrickStarClient(object):
 
             # check the chunk_id is the first to be visited.
             # local chunk as HOLD, remote chunk as RELEASED
-            if chunk_id in self.visited_chunk:
+            if chunk_id in self.visited_chunk[training_stage]:
                 return
-            self.visited_chunk[chunk_id] = 1
+            self.visited_chunk[training_stage][chunk_id] = 1
             # Find the source rank to bcast its local chunk, which owned by the gpu.
             src_rank = -1
             for cur_rank, cur_chunk_id in enumerate(chunk_id_list):

--- a/patrickstar/core/client.py
+++ b/patrickstar/core/client.py
@@ -707,19 +707,13 @@ class PatrickStarClient(object):
                 # Chunks of diff GPU are in state of HOLD_AFTER_FWD/BWD
                 chunk_ready = False
                 if training_stage == TrainingStage.FWD:
-                    if (
-                        self.chunk_list[chunk_id].all_tensor_state(
-                            TensorState.HOLD_AFTER_FWD
-                        )
-                        or self.chunk_list[chunk_id].is_dummy()
+                    if self.chunk_list[chunk_id].all_tensor_state(
+                        TensorState.HOLD_AFTER_FWD
                     ):
                         chunk_ready = True
                 elif training_stage == TrainingStage.BWD:
-                    if (
-                        self.chunk_list[chunk_id].all_tensor_state(
-                            TensorState.HOLD_AFTER_BWD
-                        )
-                        or self.chunk_list[chunk_id].is_dummy()
+                    if self.chunk_list[chunk_id].all_tensor_state(
+                        TensorState.HOLD_AFTER_BWD
                     ):
                         chunk_ready = True
 
@@ -750,7 +744,7 @@ class PatrickStarClient(object):
                         if rank != target_rank:
                             self.chunk_list[chunk_id].release_payload()
                             self.set_all_tensors_state_in_chunk(
-                                cur_chunk_id, TensorState.FREE
+                                chunk_id, TensorState.FREE
                             )
                         else:
                             self.chunk_list[chunk_id].payload /= world_size
@@ -758,7 +752,7 @@ class PatrickStarClient(object):
                         if target_rank != rank:
                             self.chunk_list[chunk_id].release_payload()
                             self.set_all_tensors_state_in_chunk(
-                                cur_chunk_id, TensorState.FREE
+                                chunk_id, TensorState.FREE
                             )
             else:
                 all_chunks_ready = True

--- a/patrickstar/core/client.py
+++ b/patrickstar/core/client.py
@@ -351,9 +351,9 @@ class PatrickStarClient(object):
                 self.chunk_list[chunk_id].get_state() == ChunkState.HOLD
                 or self.chunk_list[chunk_id].get_state() == ChunkState.RELEASED
             ):
-                has_released_chunk = True
                 return
 
+            print(f"reduce chunk_id {chunk_id} on rank {rank}")
             # Find the source rank to bcast its local chunk, which owned by the gpu.
             src_rank = -1
             for cur_rank, cur_chunk_id in enumerate(chunk_id_list):

--- a/patrickstar/core/client.py
+++ b/patrickstar/core/client.py
@@ -350,10 +350,7 @@ class PatrickStarClient(object):
 
             # check the chunk_id is the first to be visited.
             # local chunk as HOLD, remote chunk as RELEASED
-            if not (
-                self.chunk_list[chunk_id].is_dummy()
-                or (chunk_id not in self.visited_chunk)
-            ):
+            if chunk_id in self.visited_chunk:
                 return
             self.visited_chunk[chunk_id] = 1
             # Find the source rank to bcast its local chunk, which owned by the gpu.
@@ -707,6 +704,7 @@ class PatrickStarClient(object):
         if world_size > 1:
             if with_mem_saving_comm:
                 # Check if the chunk_id is ready to reduced or removed.
+                # Chunks of diff GPU are in state of HOLD_AFTER_FWD/BWD
                 chunk_ready = False
                 if training_stage == TrainingStage.FWD:
                     if (

--- a/patrickstar/core/client.py
+++ b/patrickstar/core/client.py
@@ -352,7 +352,7 @@ class PatrickStarClient(object):
             # local chunk as HOLD, remote chunk as RELEASED
             if not (
                 self.chunk_list[chunk_id].is_dummy()
-                or chunk_id not in self.visited_chunk
+                or (chunk_id not in self.visited_chunk)
             ):
                 return
             self.visited_chunk[chunk_id] = 1
@@ -388,7 +388,7 @@ class PatrickStarClient(object):
                     "CLIENT_fetch_remote_chunks_broadcast"
                 )
             # set the chunk as HOLD_AND_TOUCHED, therefore it can be offloaded to CPU.
-            self.set_all_tensors_state_in_chunk(chunk_id, TensorState.HOLD_AND_TOUCHED)
+            self.set_all_tensors_state_in_chunk(chunk_id, TensorState.HOLD)
             if rank == 0:
                 print(
                     f"state of chunk id {chunk_id} {self.chunk_list[chunk_id].get_state()}"

--- a/patrickstar/core/const.py
+++ b/patrickstar/core/const.py
@@ -43,12 +43,12 @@ class ChunkState(Enum):
     COMPUTE = 1
     # Holding meaningful data.
     HOLD = 2
-    # Holding meaningless data.
     HOLD_AFTER_FWD = 3
     HOLD_AFTER_BWD = 4
 
     # Chunk memory is not allocated.
     RELEASED = 5
+    HOLD_AND_TOUCHED = 6
 
 
 class TensorState(Enum):
@@ -65,6 +65,8 @@ class TensorState(Enum):
     HOLD = 2
     HOLD_AFTER_FWD = 3
     HOLD_AFTER_BWD = 4
+
+    HOLD_AND_TOUCHED = 5
 
 
 class TrainingStage(Enum):

--- a/patrickstar/core/const.py
+++ b/patrickstar/core/const.py
@@ -48,7 +48,6 @@ class ChunkState(Enum):
 
     # Chunk memory is not allocated.
     RELEASED = 5
-    HOLD_AND_TOUCHED = 6
 
 
 class TensorState(Enum):
@@ -65,8 +64,6 @@ class TensorState(Enum):
     HOLD = 2
     HOLD_AFTER_FWD = 3
     HOLD_AFTER_BWD = 4
-
-    HOLD_AND_TOUCHED = 5
 
 
 class TrainingStage(Enum):

--- a/patrickstar/core/hook.py
+++ b/patrickstar/core/hook.py
@@ -134,6 +134,7 @@ def pre_sub_module_forward_function(sub_module, client, name):
             AccessType.DATA,
             client.device,
             client.opt_config["with_mem_saving_comm"],
+            training_stage=TrainingStage.FWD,
         )
         flag = True
     if flag:
@@ -180,6 +181,7 @@ def pre_sub_module_backward_function(sub_module, client, name):
                 AccessType.DATA,
                 client.device,
                 client.opt_config["with_mem_saving_comm"],
+                training_stage=TrainingStage.BWD,
             )
             param.data = tmp_tensor
 

--- a/patrickstar/ops/fp16_cpu_adam.py
+++ b/patrickstar/ops/fp16_cpu_adam.py
@@ -509,7 +509,7 @@ class FP16Adam(torch.optim.Optimizer):
         if profiler.started():
             profiler.stage_convert_time.append((time.time(), TrainingStage.ADAM))
 
-        self.client.visited_chunk.reset_visited_chunk()
+        self.client.reset_visited_chunk()
         self.client.set_training_phase(TrainingStage.ADAM)
 
         self.client.trigger_memory_tracing()

--- a/patrickstar/ops/fp16_cpu_adam.py
+++ b/patrickstar/ops/fp16_cpu_adam.py
@@ -509,7 +509,7 @@ class FP16Adam(torch.optim.Optimizer):
         if profiler.started():
             profiler.stage_convert_time.append((time.time(), TrainingStage.ADAM))
 
-        self.client.visited_chunk = {{}}
+        self.client.visited_chunk.reset_visited_chunk()
         self.client.set_training_phase(TrainingStage.ADAM)
 
         self.client.trigger_memory_tracing()

--- a/patrickstar/ops/fp16_cpu_adam.py
+++ b/patrickstar/ops/fp16_cpu_adam.py
@@ -508,6 +508,8 @@ class FP16Adam(torch.optim.Optimizer):
                     self.client.release_data(param, TensorState.HOLD_AFTER_BWD)
         if profiler.started():
             profiler.stage_convert_time.append((time.time(), TrainingStage.ADAM))
+
+        self.client.visited_chunk = {}
         self.client.set_training_phase(TrainingStage.ADAM)
 
         self.client.trigger_memory_tracing()

--- a/patrickstar/ops/fp16_cpu_adam.py
+++ b/patrickstar/ops/fp16_cpu_adam.py
@@ -509,7 +509,7 @@ class FP16Adam(torch.optim.Optimizer):
         if profiler.started():
             profiler.stage_convert_time.append((time.time(), TrainingStage.ADAM))
 
-        self.client.visited_chunk = {}
+        self.client.visited_chunk = {{}}
         self.client.set_training_phase(TrainingStage.ADAM)
 
         self.client.trigger_memory_tracing()

--- a/patrickstar/runtime/engine.py
+++ b/patrickstar/runtime/engine.py
@@ -158,7 +158,7 @@ class PatrickStarEngine(torch.nn.Module):
         for _, chunk in self.client.chunk_list.generate_chunk():
             chunk.unused = 0
 
-        self.visited_chunk.reset_visited_chunk()
+        self.client.reset_visited_chunk()
 
     def _set_state_after_forward(self):
         """

--- a/patrickstar/runtime/engine.py
+++ b/patrickstar/runtime/engine.py
@@ -158,7 +158,7 @@ class PatrickStarEngine(torch.nn.Module):
         for _, chunk in self.client.chunk_list.generate_chunk():
             chunk.unused = 0
 
-        self.visited_chunk = {}
+        self.visited_chunk = {{}}
 
     def _set_state_after_forward(self):
         """
@@ -198,7 +198,7 @@ class PatrickStarEngine(torch.nn.Module):
         loss = self.module(*inputs, **kwargs)
         self._set_state_after_forward()
         global_timer.my_timer.finish_profile("FWD")
-        self.client.visited_chunk = {}
+        self.client.visited_chunk = {{}}
         return loss
 
     def backward(self, loss):

--- a/patrickstar/runtime/engine.py
+++ b/patrickstar/runtime/engine.py
@@ -217,7 +217,6 @@ class PatrickStarEngine(torch.nn.Module):
             self.loss_scaler.backward(loss)
         else:
             loss.backward()
-        self.client.visited_chunk = {}
         self.client.mem_tracer.update_margin_mem()
         self.iteration_cnt_ += 1
         global_timer.my_timer.finish_profile("BWD")

--- a/patrickstar/runtime/engine.py
+++ b/patrickstar/runtime/engine.py
@@ -196,6 +196,7 @@ class PatrickStarEngine(torch.nn.Module):
         loss = self.module(*inputs, **kwargs)
         self._set_state_after_forward()
         global_timer.my_timer.finish_profile("FWD")
+        self.client.self.visited_chunk = {}
         return loss
 
     def backward(self, loss):
@@ -216,6 +217,7 @@ class PatrickStarEngine(torch.nn.Module):
             self.loss_scaler.backward(loss)
         else:
             loss.backward()
+        self.client.self.visited_chunk = {}
         self.client.mem_tracer.update_margin_mem()
         self.iteration_cnt_ += 1
         global_timer.my_timer.finish_profile("BWD")

--- a/patrickstar/runtime/engine.py
+++ b/patrickstar/runtime/engine.py
@@ -196,7 +196,7 @@ class PatrickStarEngine(torch.nn.Module):
         loss = self.module(*inputs, **kwargs)
         self._set_state_after_forward()
         global_timer.my_timer.finish_profile("FWD")
-        self.client.self.visited_chunk = {}
+        self.client.visited_chunk = {}
         return loss
 
     def backward(self, loss):
@@ -217,7 +217,7 @@ class PatrickStarEngine(torch.nn.Module):
             self.loss_scaler.backward(loss)
         else:
             loss.backward()
-        self.client.self.visited_chunk = {}
+        self.client.visited_chunk = {}
         self.client.mem_tracer.update_margin_mem()
         self.iteration_cnt_ += 1
         global_timer.my_timer.finish_profile("BWD")

--- a/patrickstar/runtime/engine.py
+++ b/patrickstar/runtime/engine.py
@@ -158,6 +158,8 @@ class PatrickStarEngine(torch.nn.Module):
         for _, chunk in self.client.chunk_list.generate_chunk():
             chunk.unused = 0
 
+        self.visited_chunk = {}
+
     def _set_state_after_forward(self):
         """
         After forward calculation, we need to reset the state of

--- a/patrickstar/runtime/engine.py
+++ b/patrickstar/runtime/engine.py
@@ -158,7 +158,7 @@ class PatrickStarEngine(torch.nn.Module):
         for _, chunk in self.client.chunk_list.generate_chunk():
             chunk.unused = 0
 
-        self.visited_chunk = {{}}
+        self.visited_chunk.reset_visited_chunk()
 
     def _set_state_after_forward(self):
         """
@@ -198,7 +198,7 @@ class PatrickStarEngine(torch.nn.Module):
         loss = self.module(*inputs, **kwargs)
         self._set_state_after_forward()
         global_timer.my_timer.finish_profile("FWD")
-        self.client.visited_chunk = {{}}
+        self.client.reset_visited_chunk()
         return loss
 
     def backward(self, loss):


### PR DESCRIPTION
Memory saving communication (MSC): using one-to-all communication to replace the original collective communication. More specifically, reduce scatter is replaced with Nx reduce. all gather is replaced with Nx bcast. In this way, we do not need to keep a Nx chunk buffer for distributed training, therefore save the GPU memory. I have implemented MSC but may not be optimal. I triggered communication in the granularity of the chunk group (Nx chunk). This may lead to chunks frequently move between CPU and GPU.

This MR further optimizes the MSC. Communication is triggered in the granularity of chunks.
